### PR TITLE
Utilize new RetrieveConfigFile API

### DIFF
--- a/MortalEnemies/MortalEnemies.csproj
+++ b/MortalEnemies/MortalEnemies.csproj
@@ -12,7 +12,7 @@
     <ItemGroup>
         <PackageReference Include="Mutagen.Bethesda" Version="0.26.4" />
         <PackageReference Include="Mutagen.Bethesda.FormKeys.SkyrimSE" Version="1.0.0" />
-        <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.16.6" />
+        <PackageReference Include="Mutagen.Bethesda.Synthesis" Version="0.16.7" />
         <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     </ItemGroup>
 

--- a/MortalEnemies/Program.cs
+++ b/MortalEnemies/Program.cs
@@ -54,12 +54,7 @@ namespace MortalEnemies
 
         public static void RunPatch(IPatcherState<ISkyrimMod, ISkyrimModGetter> state)
         {
-            string configFile = Path.Combine(state.ExtraSettingsDataPath, "config.json");
-            string mvConfigFile = Path.Combine(state.ExtraSettingsDataPath, "move_types.json");
-            if (!File.Exists(configFile) || !File.Exists(mvConfigFile))
-                Utils.LogThrow(new ArgumentException("Config file(s) does not exist!"));
-
-            var config = Utils.FromJson<Config>(configFile);
+            var config = Utils.FromJson<Config>(state.RetrieveConfigFile("config.json"));
 
             IEnumerable<IModListing<ISkyrimModGetter>> loadOrder = state.LoadOrder.PriorityOrder;
             List<(IRaceGetter race, AttackData attackData)> races = loadOrder


### PR DESCRIPTION
Uses the new API just released to more easily fall back to "default values" of configs that dont exist in a user's data folder.

It just checks the users data folder first, and then checks the default data folder (the one that exists in the repo), and returns if it finds either.  If not, it'll then throw.

One thing I noticed was that `move_types.json` was checked for, but not used anywhere in the code?   Is that intentional?