### PR TITLE
Fix #68 forwarding movement speeds (and fix floating point in config)

### DIFF
--- a/MortalEnemies/Data/move_types.json
+++ b/MortalEnemies/Data/move_types.json
@@ -8,8 +8,8 @@
     "Forward Run":135.000000,
     "Back Walk":65.110001,
     "Back Run":98.000000,
-    "Rotate in Place Walk":180.000000,
-    "Rotate in Place Run":180.0000
+    "Rotate in Place Walk":180.00006,
+    "Rotate in Place Run":180.00006
   },
   "NPC_Blocking_MT":{
     "Left Walk":140.000000,
@@ -20,8 +20,8 @@
     "Forward Run":140.000000,
     "Back Walk":140.000000,
     "Back Run":140.000000,
-    "Rotate in Place Walk":160.000000,
-    "Rotate in Place Run":160.0000
+    "Rotate in Place Walk":160.00006,
+    "Rotate in Place Run":160.00006
   },
   "NPC_1HM_MT":{
     "Left Walk":125.000000,
@@ -32,9 +32,9 @@
     "Forward Run":290.000000,
     "Back Walk":125.000000,
     "Back Run":170.000000,
-    "Rotate in Place Walk":180.000000,
-    "Rotate in Place Run":180.0000,
-    "Rotate while Moving Run":180.0000
+    "Rotate in Place Walk":180.00006,
+    "Rotate in Place Run":180.00006,
+    "Rotate while Moving Run":180.00006
   },
   "NPC_2HM_MT":{
     "Left Walk":125.000000,
@@ -45,9 +45,9 @@
     "Forward Run":290.000000,
     "Back Walk":125.000000,
     "Back Run":170.000000,
-    "Rotate in Place Walk":180.000000,
-    "Rotate in Place Run":180.0000,
-    "Rotate while Moving Run":180.0000
+    "Rotate in Place Walk":180.00006,
+    "Rotate in Place Run":180.00006,
+    "Rotate while Moving Run":180.00006
   },
   "NPC_MagicCasting_MT":{
     "Left Walk":80.089996,

--- a/MortalEnemies/MoveTypePatcher.cs
+++ b/MortalEnemies/MoveTypePatcher.cs
@@ -67,14 +67,17 @@ namespace MortalEnemies
                 try
                 {
                     var newMoveType = moveType.DeepCopy();
-                    newMoveType.LeftWalk = mtData[moveType.EditorID]["Left Walk"];
-                    newMoveType.LeftRun = mtData[moveType.EditorID]["Left Run"];
-                    newMoveType.RightWalk = mtData[moveType.EditorID]["Right Walk"];
-                    newMoveType.RightRun = mtData[moveType.EditorID]["Right Run"];
-                    newMoveType.ForwardWalk = mtData[moveType.EditorID]["Forward Walk"];
-                    newMoveType.ForwardRun = mtData[moveType.EditorID]["Forward Run"];
-                    newMoveType.BackWalk = mtData[moveType.EditorID]["Back Walk"];
-                    newMoveType.BackRun = mtData[moveType.EditorID]["Back Run"];
+                    if (!this.settings.NoRunWalkChanges)
+                    {
+                        newMoveType.LeftWalk = mtData[moveType.EditorID]["Left Walk"];
+                        newMoveType.LeftRun = mtData[moveType.EditorID]["Left Run"];
+                        newMoveType.RightWalk = mtData[moveType.EditorID]["Right Walk"];
+                        newMoveType.RightRun = mtData[moveType.EditorID]["Right Run"];
+                        newMoveType.ForwardWalk = mtData[moveType.EditorID]["Forward Walk"];
+                        newMoveType.ForwardRun = mtData[moveType.EditorID]["Forward Run"];
+                        newMoveType.BackWalk = mtData[moveType.EditorID]["Back Walk"];
+                        newMoveType.BackRun = mtData[moveType.EditorID]["Back Run"];
+                    }
 
                     newMoveType.RotateInPlaceWalk = mtData[moveType.EditorID]["Rotate in Place Walk"];
                     newMoveType.RotateInPlaceRun = mtData[moveType.EditorID]["Rotate in Place Run"];

--- a/MortalEnemies/Settings.cs
+++ b/MortalEnemies/Settings.cs
@@ -10,5 +10,6 @@ namespace MortalEnemies
     public class Settings
     {
         public AttackCommitment CommitmentMode = AttackCommitment.Original;
+        public bool NoRunWalkChanges = false;
     }
 }


### PR DESCRIPTION
This PR adds "NoRunWalkChanges" as an option (imitating the original Mortal Enemies ESP name that left the walk/run speeds at vanilla values), which retains the load order's walk/run speeds, fixing #68.

I also noticed in SSEEdit that 180.0000 was being read as/converted to 179.9999 (and similarly for 160) which was causing conflicts. The original 180 value actually printed out as 180.00006 while I was testing the NoRunWalkChanges, and changing these values in the config fixes the conflicts.